### PR TITLE
Fix bug in forcejump()

### DIFF
--- a/R/functions_corr.R
+++ b/R/functions_corr.R
@@ -107,6 +107,7 @@ forcejump <- function(data_L2, force, n_days = 5) {
     dplyr::mutate(diff = c(NA, diff(value, lag = 1))) %>%
     dplyr::select(ts, diff) %>%
     dplyr::right_join(., data_L2, by = "ts") %>%
+    dplyr::arrange(ts) %>%
     dplyr::select(diff) %>%
     unlist(., use.names = FALSE)
 


### PR DESCRIPTION
Fixes bug whereby missing values or previously corrected values with proc_dendro where not in the right place when calculating the value diff for determining the corrected value after doing a force jump.