### PR TITLE
Clear flags when reversing prior to do other manual corrections

### DIFF
--- a/R/corr_dendro_L2.R
+++ b/R/corr_dendro_L2.R
@@ -121,18 +121,22 @@ corr_dendro_L2 <- function(dendro_L1 = NULL, dendro_L2, reverse = NULL,
                                 reverse = reverse, tz = tz)
     df <- reverse_list[[1]]
     diff_old <- reverse_list[[2]]
+    
+    # unset previous fill / out / jump flags and set the 'rev' flag
+    df <- revflags(df = df)
   }
+  
   if (length(force) != 0) {
     df <- forcejump(data_L2 = df, force = force, n_days = n_days)
   }
+  
   if (length(delete) != 0) {
     df <- deleteperiod(df = df, delete = delete)
   }
 
   df <- calcmax(df = df)
   df <- calctwdgro(df = df, tz = tz)
-  df <- summariseflagscorr(df = df, reverse = reverse, force = force,
-                           delete = delete)
+  df <- summariseflagscorr(df = df, force = force, delete = delete)
 
   df <- df %>%
     dplyr::mutate(gro_yr = ifelse(is.na(value), NA, gro_yr)) %>%


### PR DESCRIPTION
Firts clear flags of previous changes made by treenetproc, add the 'rev' flag and then do the other manual corrections.

This comes out from the need that sometimes we want to reverse a change made by treenetproc and, at the same item position, force a jump. With the previous code, the force jump got a NA value since there was a 'fill' flag when the forcejump function was executing (see second statement of the forcejump function). This was because removing the previous flags and setting the 'rev' flag was done after all the corrections are made.